### PR TITLE
Merge changes from v2.0.1-next.1 into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [2.0.1-next.1](https://github.com/Nerdware-LLC/fixit-api/compare/v2.0.0...v2.0.1-next.1) (2024-03-10)
+
 # [2.0.0](https://github.com/Nerdware-LLC/fixit-api/compare/v1.23.1...v2.0.0) (2024-03-10)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fixit-api",
-  "version": "2.0.0",
+  "version": "2.0.1-next.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fixit-api",
-      "version": "2.0.0",
+      "version": "2.0.1-next.1",
       "license": "LicenseRef-LICENSE",
       "dependencies": {
         "@apollo/server": "^4.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixit-api",
-  "version": "2.0.0",
+  "version": "2.0.1-next.1",
   "description": "Fixit API services built on NodeJS and Apollo GraphQL.",
   "author": {
     "name": "Trevor Anderson",


### PR DESCRIPTION
Merge changes from [v2.0.1-next.1][src-tag] into [main][main-branch].

Details regarding the included changes are provided in the [release notes][src-tag] and the [CHANGELOG][main-changelog].

[src-tag]: https://github.com/Nerdware-LLC/fixit-api/releases/tag/v2.0.1-next.1

<!-- DEFAULT DEST: main branch -->

[main-branch]: https://github.com/Nerdware-LLC/fixit-api/tree/main
[main-changelog]: https://github.com/Nerdware-LLC/fixit-api/tree/main/CHANGELOG.md
